### PR TITLE
Add option to shuffle memcache servers before processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ optional arguments:
   --key KEY   Shodan API key.
   --out OUT   Output directory for caches.
   --json      Output as JSON. (Default: CSV)
+  --continue  Skip servers already listed in output directory ie continue a previous run
+  --shuffle	  Shuffle the list of servers from Shodan so they're queried in a random order
 ```
 
 You must supply your Shodan API `--key`. 

--- a/mcd.py
+++ b/mcd.py
@@ -94,7 +94,7 @@ def get_servers(api_key, shuffleflag, continue_flag, outdir):
     if continue_flag:
         # Get files currently in output directory and remove .csv or .json extension so we just have the IP address
         currentfiles = [os.path.splitext(f)[0] for f in listdir(outdir) if isfile(join(outdir, f))]
-        memcached_servers = [x for x in memcached_servers if x not in currentfiles]     
+        memcached_servers = [x for x in memcached_servers if x["ip_str"] not in currentfiles]     
     if shuffleflag:
         shuffle(memcached_servers)
     return memcached_servers

--- a/mcd.py
+++ b/mcd.py
@@ -6,7 +6,7 @@ import json
 import csv
 import argparse
 import os
-from random import shuffle
+
 
 def make_query(query, s, chunk=4096):
     s.sendall("{}\r\n".format(query).encode())
@@ -75,7 +75,7 @@ def scrape(server, outdir, as_json):
         print("[+] Wrote CSV to {}".format(fname))
 
 
-def get_servers(api_key, shuffleflag):
+def get_servers(api_key):
     api = shodan.Shodan(api_key)
     memcached_servers = []
     try:
@@ -88,8 +88,6 @@ def get_servers(api_key, shuffleflag):
                 result["ip_str"]))
     except shodan.APIError as e:
         print("[-] Shodan error: %s" % e)
-    if shuffleflag:
-        shuffle(memcached_servers)
     return memcached_servers
 
 
@@ -103,12 +101,10 @@ parser.add_argument(
     action="store_true",
     default=False,
     help="Output as JSON. (Default: CSV)")
-parser.add_argument('--shuffle', dest='shuffleflag', action='store_true', help="Shuffle the list of memcached servers before querying.")
-
 args = parser.parse_args()
 if not os.path.exists(args.out):
     os.makedirs(args.out)
-for server in get_servers(args.key, args.shuffleflag):
+for server in get_servers(args.key):
     try:
         scrape(server, args.out, args.json)
     except Exception as e:

--- a/mcd.py
+++ b/mcd.py
@@ -6,7 +6,7 @@ import json
 import csv
 import argparse
 import os
-
+from random import shuffle
 
 def make_query(query, s, chunk=4096):
     s.sendall("{}\r\n".format(query).encode())
@@ -75,7 +75,7 @@ def scrape(server, outdir, as_json):
         print("[+] Wrote CSV to {}".format(fname))
 
 
-def get_servers(api_key):
+def get_servers(api_key, shuffleflag):
     api = shodan.Shodan(api_key)
     memcached_servers = []
     try:
@@ -88,6 +88,8 @@ def get_servers(api_key):
                 result["ip_str"]))
     except shodan.APIError as e:
         print("[-] Shodan error: %s" % e)
+    if shuffleflag:
+        shuffle(memcached_servers)
     return memcached_servers
 
 
@@ -101,10 +103,12 @@ parser.add_argument(
     action="store_true",
     default=False,
     help="Output as JSON. (Default: CSV)")
+parser.add_argument('--shuffle', dest='shuffleflag', action='store_true', help="Shuffle the list of memcached servers before querying.")
+
 args = parser.parse_args()
 if not os.path.exists(args.out):
     os.makedirs(args.out)
-for server in get_servers(args.key):
+for server in get_servers(args.key, args.shuffleflag):
     try:
         scrape(server, args.out, args.json)
     except Exception as e:


### PR DESCRIPTION
This commit adds the option to randomize the list of memcache servers before processing rather than have them always follow the sequence they are returned from Shodan